### PR TITLE
Add text region parser

### DIFF
--- a/doc/source/configFile.rst
+++ b/doc/source/configFile.rst
@@ -80,7 +80,7 @@ This default configuration matches a .DA1 file with the following format:
 region_fields
 ~~~~~~~~~~~~~
 
-Similar to ``da1_fields``, this section specifies the positions of values in each line of a region file. Region files (typically .cnt or .reg) describe regions of interest in items of the experiment. Regions are defined by a character position of the beginning and ending of the region. Character positions can either be a single integer for single-line items, or a pair (line, character) of integers for multi-line items. A line in a region file contains the number and condition of an item, followed by the beginning and end positions of the regions. Four fields are necessary for parsing a region file.
+Similar to ``da1_fields``, this section specifies the positions of values in each line of a region file. If the newer text region format is used, this section of the configuration is ignored. Region files (typically .cnt or .reg) describe regions of interest in items of the experiment. Regions are defined by a character position of the beginning and ending of the region. Character positions can either be a single integer for single-line items, or a pair (line, character) of integers for multi-line items. A line in a region file contains the number and condition of an item, followed by the beginning and end positions of the regions. Four fields are necessary for parsing a region file.
 
 ``number``: Item identifier.
 

--- a/doc/source/start.rst
+++ b/doc/source/start.rst
@@ -54,8 +54,8 @@ This default configuration matches a .DA1 file with the following format:
 
 If your .DA1 files do not match this format, copy :doc:`default_config.json <default_config.json>` into a new file in the same directory, and edit the ``da1_fields`` section to match your .DA1 file format.
 
-Region File Formats
-~~~~~~~~~~~~~~~~~~~
+Numeric Region File Formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Region files (typically .cnt or .reg) describe regions of interest in items of the experiment. Regions are defined by a character position of the beginning and ending of the region. Character positions can either be a single integer for single-line items, or a pair (line, character) of integers for multi-line items. A line in a region file contains the number and condition of an item, followed by the beginning and end positions of the regions. Four fields are necessary for parsing a region file.
 
@@ -87,6 +87,26 @@ The default configuration matches a region file with the following format:
   Value:    num.  | cond. |   |  r1   |  r1   |  r2   |  r2   | ... |
 
 If your region file does not match this format, copy :doc:`default_config.json <default_config.json>` into a new file in the same directory, and edit the ``region_fields`` section to match your region file format.
+
+Text Region File Formats
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Text region files are a new format for use with SideEye. This format can be used instead of a .cnt or .reg file, and allows for region length to be calculated automatically, and for region text to be included in the experiment output. There is only one format for this type of region file, so the ``region_fields`` configuration section is ignored. In this format, each line represents an item.
+
+In this format, each line should have a number or string identifying the item number, followed by a tab or space, a number or string identifying the item condition, another tab or space, and then the text of the item. In the region text, regions are separated by the ``/`` character, and lines are separated by ``\n``.
+
+For example, the following line represents an item with number 1, condition 3, and four regions on two lines:
+
+::
+
+  1    3    This is an item/ with two lines/\nand four/ regions.
+
+The item displayed by the eye tracker would be:
+
+::
+
+  This is an item with two lines
+  and four regions.
 
 Parsing The Experiment
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/sideeye/calculate.py
+++ b/sideeye/calculate.py
@@ -5,7 +5,8 @@ experiment. These functions do not return anything, they only calculate the meas
 or measures on each trial or region of the experiments.
 """
 
-import json, os
+import json
+import os
 from . import measures
 from .output import generate_all_output, generate_all_output_wide_format
 

--- a/sideeye/output.py
+++ b/sideeye/output.py
@@ -3,7 +3,8 @@ This module contains functions to generate csv reports of measures calculated
 for experiments.
 """
 
-import json, os
+import json
+import os
 
 DEFAULT_CONFIG = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'default_config.json')
 

--- a/sideeye/parser/experiment.py
+++ b/sideeye/parser/experiment.py
@@ -21,7 +21,7 @@ def parse(da1_file, region_file, config_file=DEFAULT_CONFIG):
 
     Args:
         da1_file (str): Name of DA1 file.
-        region_file: Name of region file (.cnt or .reg).
+        region_file: Name of region file (.cnt, .reg, or .txt).
         config_file: Name of configuration file.
     """
     config = load_config(config_file)
@@ -30,12 +30,15 @@ def parse(da1_file, region_file, config_file=DEFAULT_CONFIG):
     cutoffs = config['cutoffs']
     verbose = config['terminal_output']
 
-    items = parser.region.file(region_file,
-                               region_config['number'],
-                               region_config['condition'],
-                               region_config['boundaries_start'],
-                               region_config['includes_y'],
-                               verbose=verbose)
+    if region_file[-4:].lower() == '.txt':
+        items = parser.region.textfile(region_file, verbose=verbose)
+    else:
+        items = parser.region.file(region_file,
+                                   region_config['number'],
+                                   region_config['condition'],
+                                   region_config['boundaries_start'],
+                                   region_config['includes_y'],
+                                   verbose=verbose)
 
     experiment = parser.da1.parse(da1_file,
                                   items,
@@ -58,7 +61,7 @@ def parse_dir(da1_directory, region_file, config_file=DEFAULT_CONFIG):
 
     Args:
         da1_directory: Name of directory containing DA1 files.
-        region_file: Name of region file (.cnt or .reg).
+        region_file: Name of region file (.cnt, .reg, or .txt).
         config_file: Name of configuration file.
     """
     config = load_config(config_file)
@@ -69,12 +72,15 @@ def parse_dir(da1_directory, region_file, config_file=DEFAULT_CONFIG):
     cutoffs = config['cutoffs']
     verbose = config['terminal_output']
 
-    items = parser.region.file(region_file,
-                               region_config['number'],
-                               region_config['condition'],
-                               region_config['boundaries_start'],
-                               region_config['includes_y'],
-                               verbose=verbose)
+    if region_file[-4:].lower() == '.txt':
+        items = parser.region.textfile(region_file, verbose=verbose)
+    else:
+        items = parser.region.file(region_file,
+                                   region_config['number'],
+                                   region_config['condition'],
+                                   region_config['boundaries_start'],
+                                   region_config['includes_y'],
+                                   verbose=verbose)
     experiments = []
     for da1 in da1s:
         if da1[-4:].lower() != '.da1':

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -99,24 +99,5 @@ with such.A('Parser') as it:
             with it.assertRaises(ValueError):
                 parser.region.file(os.path.join(it.dirname, 'testdata/robodoc.DA1'), number_location=1, condition_location=0)
 
-    with it.having('Region string parser'):
-        @it.has_setup
-        def setup():
-            it.dirname = os.path.dirname(os.path.realpath(__file__))
-            it.region = parser.region.text('This is/ a string/ with four/ regions')
-            it.parsed_regions = [Region(Point(0, 0), Point(7, 0), 7, 'This is'),
-                                 Region(Point(7, 0), Point(16, 0), 9, ' a string'),
-                                 Region(Point(16, 0), Point(26, 0), 10, ' with four'),
-                                 Region(Point(26, 0), Point(34, 0), 8, ' regions')]
-
-        @it.should('parse a region string')
-        def test_region_string():
-            it.assertEqual(it.region, it.parsed_regions)
-
-        @it.should('throw an error when given a non-region string input')
-        def test_non_region_string():
-            with it.assertRaises(ValueError):
-                parser.region.text(1)
-
 
 it.createTests(globals())

--- a/tests/test_region_string_parsing.py
+++ b/tests/test_region_string_parsing.py
@@ -1,0 +1,69 @@
+import os
+
+from sideeye import parser, Point, Fixation, Trial, Region, Item
+
+from nose2.tools import such
+
+class TestData(object):
+
+    @classmethod
+    def setUp(cls):
+        it.testdata = True
+
+    @classmethod
+    def tearDown(cls):
+        del it.testdata
+
+with such.A('Region String Parser') as it:
+    with it.having('single item region string parser'):
+        @it.has_setup
+        def setup():
+            it.region = parser.region.text('This is/ a string/ with four/ regions')
+            it.parsed_regions = [Region(Point(0, 0), Point(7, 0), 7, 'This is'),
+                                 Region(Point(7, 0), Point(16, 0), 9, ' a string'),
+                                 Region(Point(16, 0), Point(26, 0), 10, ' with four'),
+                                 Region(Point(26, 0), Point(34, 0), 8, ' regions')]
+
+        @it.should('parse a region string')
+        def test_region_string():
+            it.assertEqual(it.region, it.parsed_regions)
+
+        @it.should('throw an error when given a non-region string input')
+        def test_non_region_string():
+            with it.assertRaises(ValueError):
+                parser.region.text(1)
+
+    with it.having('text file region string parser'):
+        @it.has_setup
+        def setup():
+            it.dirname = os.path.dirname(os.path.realpath(__file__))
+            it.txt_items = parser.region.textfile(os.path.join(it.dirname, 'testdata/regionstring.txt'))
+
+        @it.should('parse a region string text file')
+        def test_region_string_file():
+            it.assertEqual(it.txt_items[1][1],
+                           Item(1, 1, [Region(Point(0, 0), Point(17, 0), 17, 'this is region 1 '),
+                                       Region(Point(17, 0), Point(33, 0), 16, 'this is region 2'),
+                                       Region(Point(33, 0), Point(50, 0), 17, ' this is region 3'),
+                                       Region(Point(50, 0), Point(18, 1), 18, 'this is a new line'),
+                                       Region(Point(18, 1), Point(40, 1), 22, 'this is another region'),
+                                       Region(Point(40, 1), Point(20, 2), 20, 'this is a third line')]))
+            it.assertEqual(it.txt_items[1][2],
+                           Item(1, 2, [Region(Point(0, 0), Point(20, 0), 20, 'item with one region')]))
+            it.assertEqual(it.txt_items[2][1],
+                           Item(2, 1, [Region(Point(0, 0), Point(9, 0), 9, 'item with'),
+                                       Region(Point(9, 0), Point(19, 1), 19, 'one region per line')]))
+            it.assertEqual(it.txt_items[2][2],
+                           Item(2, 2, [Region(Point(0, 0), Point(8, 0), 8, 'this is '),
+                                       Region(Point(8, 0), Point(16, 0), 8, 'an item '),
+                                       Region(Point(16, 0), Point(20, 0), 4, 'with'),
+                                       Region(Point(20, 0), Point(12, 1), 12, 'three lines '),
+                                       Region(Point(12, 1), Point(22, 1), 10, 'of regions'),
+                                       Region(Point(22, 1), Point(21, 2), 21, 'and multiple regions '),
+                                       Region(Point(21, 2), Point(29, 2), 8, 'per line')]))
+            it.assertEqual(it.txt_items[3][1],
+                           Item(3, 1, [Region(Point(0, 0), Point(10, 1), 20, 'this is an\nitem with '),
+                                       Region(Point(10, 1), Point(46, 1), 36, 'a new line in the middle of a region')]))
+
+
+it.createTests(globals())

--- a/tests/testdata/regionstring.txt
+++ b/tests/testdata/regionstring.txt
@@ -1,0 +1,5 @@
+1 1 this is region 1 /this is region 2/ this is region 3/\nthis is a new line/this is another region/\nthis is a third line
+1 2 item with one region
+2 1 item with/\none region per line
+2 2 this is /an item /with/\nthree lines /of regions/\nand multiple regions /per line
+3     1 this is an\nitem with /a new line in the middle of a region


### PR DESCRIPTION
Parses regions as text format.

@bdillon @lizschotter @mehrdadv86 if you have a chance to look at the changes to the documentation and the way things are handled in the [tests](https://github.com/amnda-d/sideeye/blob/4aca85aea19a930bf689760767461cd3fc9b903f/tests/test_region_string_parsing.py#L36) that would be great!

Closes #6 